### PR TITLE
Adding allocation_id to EC2.associate_address() to support VPC EIPs, improved suggested IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,27 +19,43 @@ objects such as route tables. Here is the basic IAM role permissions set necessa
 is called out as [ "arn:aws:ec2:::*" ] simply because the vpc object IDS are unknown:
 ```
 {
+  "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "Stmt1436895015000",
       "Effect": "Allow",
-      "Resource": [
-          "arn:aws:ec2:::*"
+      "Action": [
+        "ec2:DescribeAvailabilityZones",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:DescribeInstanceAttribute",
+        "ec2:DescribeRegions",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ReplaceRoute",
+        "ec2:CreateRoute",
+        "ec2:ReplaceRouteTableAssociation",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeRouteTables",
+        "ec2:AssociateAddress",
+        "ec2:DescribeAddresses",
+        "ec2:DisassociateAddress",
+        "ec2:DescribeInstances"
       ],
-      "Action": [ 
-          "ec2:DescribeAvailabilityZones",
-          "ec2:ModifyInstanceAttribute",
-          "ec2:DescribeInstanceAttribute",
-          "ec2:DescribeRegions",
-          "ec2:ModifyInstanceAttribute",
-          "ec2:ReplaceRoute",
-          "ec2:CreateRoute",
-          "ec2:ReplaceRouteTableAssociation",
-          "ec2:DescribeSubnets",
-          "ec2:DescribeRouteTables",
-          "ec2:AssociateAddress",
-          "ec2:DescribeAddresses",
-          "ec2:DisassociateAddress"
-      ]
+      "Resource": [
+        "*"
+      ],
+      "Condition": {
+        "ForAllValues:StringEquals": {
+          "ec2:ResourceTag/aws:autoscaling:groupName": "<autoscaling group name>"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcs",
+        "ec2:DescribeRouteTables"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Highly Available NAT cluster
 
-This RPM package will ensure availability of a NAT instance when run in an autoscaling group.
+I'm sorry to say this probably won't work for you, this is a customized fork that meets specific
+requirements for a test environment.
 
 It can be used on a single NAT instance in a VPC, or in an HA configuration with 1 NAT per AZ in the VPC.
 

--- a/ha-nat.py
+++ b/ha-nat.py
@@ -244,7 +244,7 @@ def main():
                         continue
                     if address.public_ip == eip_assigned:
                         log("found matching usable ip %s - associating to this instance [%s]" % (eip_assigned, getInstanceId()))
-                        EC2.associate_address(instance_id = getInstanceId(), public_ip = eip_assigned)
+                        EC2.associate_address(instance_id = getInstanceId(), public_ip = eip_assigned, allocation_id = address.allocation_id)
                         have_eip = True
                 ## we should have an eip here now, if not lets raise an exception
                 raise Exception("Expected to have an EIP at this point, but do not")


### PR DESCRIPTION
I had an issue where my VPC EIP failed to associate to my instance. Passing the allocation_id fixed this for me.

```
2015-10-06 12:25:27.883407 - disabling source/destination checks
2015-10-06 12:25:28.195002 - we have been asked to handle eips - handling now
2015-10-06 12:25:28.340326 - got addresses: []
2015-10-06 12:25:28.340391 - no EIP assigned to this instance - looking for EIPS
2015-10-06 12:25:28.340428 - eips have been specified
2015-10-06 12:25:28.340461 -  - searching for x.x.x.x
2015-10-06 12:25:28.396675 -  - found address: Address:x.x.x.x
2015-10-06 12:25:28.396750 - found matching usable ip x.x.x.x - associating to this instance [i-00340aa0]
2015-10-06 12:25:28.468856 - ERROR: EC2ResponseError: 400 Bad Request
2015-10-06 12:25:28.468856 -    <?xml version="1.0" encoding="UTF-8"?>
2015-10-06 12:25:28.468856 -    <Response><Errors><Error><Code>InvalidParameterCombination</Code><Message>You must specify an allocation id when mapping an address to a VPC instance</Message></Error></Errors><RequestID>2a6f6c90-f2e1-4699-94e7-edc9bd7396e2</RequestID></Response>
2015-10-06 12:25:28.468916 - sleeping 5 before rechecking
```

The sample IAM policy was missing a few required attributes, and I added a conditional to limit modify operations to instances in the same ASG. Considering that this host is exposed to the public network it will help contain the blast radius should a security incident occur.
